### PR TITLE
Fixing Config implementation in template and final

### DIFF
--- a/plugins/gobuilder_final/builder/builder.go
+++ b/plugins/gobuilder_final/builder/builder.go
@@ -20,8 +20,8 @@ type Builder struct {
 }
 
 // Implement Configurable
-func (b *Builder) Config() interface{} {
-	return &b.config
+func (b *Builder) Config() (interface{}, error) {
+	return &b.config, nil
 }
 
 // Implement ConfigurableNotify

--- a/template/builder/builder.go
+++ b/template/builder/builder.go
@@ -16,8 +16,8 @@ type Builder struct {
 }
 
 // Implement Configurable
-func (b *Builder) Config() interface{} {
-	return &b.config
+func (b *Builder) Config() (interface{}, error) {
+	return &b.config, nil
 }
 
 // Implement ConfigurableNotify


### PR DESCRIPTION
The plugin devolpment tutorial has the correct Config signature in the
text, but the video version and the template/final code in this repo
are missing the error. Failure to implement Configurable interface leads
to the config params in the HCL files to be silently ignored.