### PR TITLE
Fix typo in clone script

### DIFF
--- a/template/clone.sh
+++ b/template/clone.sh
@@ -45,7 +45,7 @@ fi
 cp -R . $1
 process $1 $2
 
-echo "Created new pluging in $1"
+echo "Created new plugin in $1"
 echo "You can build this plugin by running the following command"
 echo ""
 echo "cd $1 && make"


### PR DESCRIPTION
This fixes 'pluging' to 'plugin' in clone.sh.

Apologies for the newline - I use vim, and it's a pain to have it not do that.