### PR TITLE
Exit after printing help text

### DIFF
--- a/template/clone.sh
+++ b/template/clone.sh
@@ -25,6 +25,7 @@ for arg in "$@"
 do
     if [ "$arg" == "--help" ] || [ "$arg" == "-h" ]; then
       help
+      exit 0
     fi
 done
 


### PR DESCRIPTION
Currently, when running `clone.sh --help`, the script will continue
executing once the help text has printed and will error when it can't
find a positional argument for the location to clone to. This adds `exit
0` after printing the help text so that just the help text is printed,
and the script succeeds and don't error incorrectly.