### PR TITLE
Fix typo in Gobuilder readme

### DIFF
--- a/plugins/gobuilder_final/README.md
+++ b/plugins/gobuilder_final/README.md
@@ -1,3 +1,3 @@
-# Gobulder Plugin
+# Gobuilder Plugin
 
 This plugin is the final example from the Waypoint plugin development guide


### PR DESCRIPTION
Fixed typo I noticed in the title of the Gobuilder readme.

Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>