### PR TITLE
Fix failure of build of filepath plugin.

### DIFF
--- a/plugins/filepath/Makefile
+++ b/plugins/filepath/Makefile
@@ -1,9 +1,11 @@
 .PHONY: protos build
 
+.DEFAULT_GOAL := build
+
 protos:
 	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./registry/output.proto
 	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./platform/output.proto
 	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./release/output.proto
 
-build:
+build: protos
 	CGO_ENABLED=0 go build -o ./bin/waypoint-plugin-filepath ./*.go

--- a/plugins/filepath/main.go
+++ b/plugins/filepath/main.go
@@ -2,7 +2,7 @@
 package main
 
 import (
-	"github.com/hashicorp/waypoint-plugin-examples/plugins/filepath/deploy"
+	"github.com/hashicorp/waypoint-plugin-examples/plugins/filepath/platform"
 	"github.com/hashicorp/waypoint-plugin-examples/plugins/filepath/registry"
 	"github.com/hashicorp/waypoint-plugin-examples/plugins/filepath/release"
 	sdk "github.com/hashicorp/waypoint-plugin-sdk"
@@ -15,7 +15,7 @@ import (
 func main() {
 	sdk.Main(sdk.WithComponents(
 		&registry.Registry{},
-		&deploy.Deploy{},
+		&platform.Deploy{},
 		&release.Releaser{},
 	))
 }


### PR DESCRIPTION
Fixes:
* `waypoint-plugin-filepath` is not built by make.
* An import path.

I got this error before my fixes.
```
$ make

### Build Go Builder Plugin
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C gobuilder_final

Build Protos
protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./builder/output.proto

Compile Plugin
go build -o ./bin/waypoint-plugin-gobuilder ./main.go


### Build Filepath Builder Plugin
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C filepath
protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./registry/output.proto
protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./platform/output.proto
protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./release/output.proto


### Install Plugins
mkdir -p ./example_app/.waypoint/plugins
cp ./gobuilder_final/bin/* ./example_app/.waypoint/plugins
cp ./filepath/bin/* ./example_app/.waypoint/plugins
cp: ./filepath/bin/*: No such file or directory
make: *** [all] Error 1
```