### PR TITLE
Update proto generation

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -14,10 +14,10 @@ protos:
 	@echo ""
 	@echo "Build Protos"
 
-	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./builder/output.proto
-	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./registry/output.proto
-	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./platform/output.proto
-	protoc -I . --go_out=plugins=grpc:. --go_opt=paths=source_relative ./release/output.proto
+	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative builder/output.proto
+	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative registry/output.proto
+	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative platform/output.proto
+	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative release/output.proto
 
 # Builds the plugin on your local machine
 build:


### PR DESCRIPTION
When using latest proto plugins:
google.golang.org/protobuf/cmd/protoc-gen-go@v1.26 
google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.1

protoc --version
libprotoc 3.17.0

getting error:
--go_out: protoc-gen-go: plugins are not supported; use 'protoc --go-grpc_out=...' to generate gRPC


This changes fix proto generation issue.